### PR TITLE
Add readable permission to data resources (create, update, delete)

### DIFF
--- a/config_generator/data_service_config.py
+++ b/config_generator/data_service_config.py
@@ -357,7 +357,13 @@ class DataServiceConfig(ServiceConfig):
                 creatable |= layer_name in \
                     role_permissions['data_create'].get(map_name, {})
                 readable |= layer_name in \
-                    role_permissions['data_read'].get(map_name, {})
+                    role_permissions['data_read'].get(map_name, {}) \
+                    or layer_name in \
+                    role_permissions['data_create'].get(map_name, {}) \
+                    or layer_name in \
+                    role_permissions['data_update'].get(map_name, {}) \
+                    or layer_name in \
+                    role_permissions['data_delete'].get(map_name, {}) 
                 updatable |= layer_name in \
                     role_permissions['data_update'].get(map_name, {})
                 deletable |= layer_name in \


### PR DESCRIPTION
Hello, 

I notice that when `readable` permission is not set, it is impossible to open edit form. 

So this permission is necessary to use resources with type below : 
- data (create)
- data (update)
- data (delete)

I propose this fix...

Have a good day

Gwendoline Andres
Oslandia