### PR TITLE
Fix categorize layer bug where layer source paths were changed wrongly

### DIFF
--- a/config_generator/categorize_groups_script.py
+++ b/config_generator/categorize_groups_script.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 from qgis.core import *
 
 
@@ -24,15 +25,6 @@ def split_categorized_layers(src_path, dest_path=None):
     :param string src_path: Absolute path to the project file(*.qgs file)
     :param string dest_path: Absolute path to the destination project
     """
-
-    if dest_path is None:
-        file_name, extension = os.path.splitext(src_path)
-        dest_path = file_name + "_categorized" + extension
-
-    return categorize_layers(src_path, dest_path)
-
-
-def categorize_layers(src_path, dest_path):
 
     layer_order = []
     layers = []
@@ -84,7 +76,13 @@ def categorize_layers(src_path, dest_path):
             project_instance, group)
         project_instance.removeMapLayer(base_layer)
 
-    project_instance.write(dest_path)
+    # Create new file name to not overide the old project
+    file_name, extension = os.path.splitext(src_path)
+    categorized_project_path = file_name + "_categorized" + extension
+    project_instance.write(categorized_project_path)
+
+    if dest_path is not None:
+        shutil.move(categorized_project_path, dest_path)
 
     return dest_path
 

--- a/config_generator/categorize_groups_script.py
+++ b/config_generator/categorize_groups_script.py
@@ -1,4 +1,5 @@
 import os
+import glob
 import shutil
 from qgis.core import *
 
@@ -82,7 +83,31 @@ def split_categorized_layers(src_path, dest_path=None):
     project_instance.write(categorized_project_path)
 
     if dest_path is not None:
-        shutil.move(categorized_project_path, dest_path)
+
+        # Specify destination directory
+        if os.path.isdir(dest_path):
+            dest_path_dir = dest_path
+        else:
+            dest_path_dir = os.path.dirname(dest_path)
+
+        for file in glob.glob(os.path.splitext(categorized_project_path)[0] + "*"):
+            # Specify destination file name
+            if os.path.isdir(dest_path):
+                # dest_path is only a directory so we don't have to change the file name
+                dest_file_name = os.path.basename(file)
+            else:
+                # dest_path is a file that means we have to rename the project file
+                # This is done by taking the current project file name and replacing
+                # everything before our own "_categorized" infix with the new file name
+                file_name, extension = os.path.splitext(os.path.basename(file))
+                dest_file_name = (
+                    os.path.splitext(os.path.basename(dest_path))[0]
+                    + "_categorized"
+                    + file_name.split("_categorized")[1]
+                    + extension
+                )
+
+            shutil.move(file, os.path.join(dest_path_dir, dest_file_name))
 
     return dest_path
 


### PR DESCRIPTION
The problem with the current approach is that relative paths are stored depending on the path of the QGIS project. When we use QgsProject to write the project to a new location then QGIS will update the layer sources to be relative to the new project location. This obviously breaks layers.
The new approach makes sure the project is stored in the same directory as the old project (which is the default behavior if no destination location is specified) and then moves the project to the correct path with the correct name. This makes sure no layer sources are changed and everything is kept as is.