### PR TITLE
Generate configuration for qwc-oidc-auth service

### DIFF
--- a/src/config_generator/config_generator.py
+++ b/src/config_generator/config_generator.py
@@ -315,6 +315,10 @@ class ConfigGenerator():
                 'ldapAuth', self.schema_urls.get('ldapAuth'),
                 self.service_config('ldapAuth'), self.logger, 'ldap-auth'
             ),
+            'oidcAuth': ServiceConfig(
+                'oidcAuth', self.schema_urls.get('oidcAuth'),
+                self.service_config('oidcAuth'), self.logger, 'oidc-auth'
+            ),
             'elevation': ServiceConfig(
                 'elevation', self.schema_urls.get('elevation'),
                 self.service_config('elevation'), self.logger

--- a/src/schema-versions.json
+++ b/src/schema-versions.json
@@ -45,6 +45,10 @@
       "schema_url": "https://github.com/qwc-services/qwc-ogc-service/raw/master/schemas/qwc-ogc-service.json"
     },
     {
+      "service": "oidcAuth",
+      "schema_url": "https://github.com/qwc-services/qwc-oidc-auth/raw/main/schemas/qwc-oidc-auth.json"
+    },
+    {
       "service": "permalink",
       "schema_url": "https://github.com/qwc-services/qwc-permalink-service/raw/master/schemas/qwc-permalink-service.json"
     },


### PR DESCRIPTION
Hi,

This PR aims to generate configuration for [qwc-oidc-auth service](https://github.com/qwc-services/qwc-oidc-auth) in the `OUTPUT_CONFIG_PATH` directory.

I plan to automatically generate config-only services to avoid to add another code block for any new service in the future here https://github.com/qwc-services/qwc-config-generator/blob/master/src/config_generator/config_generator.py#L305

Please tell me if this is not a good idea.

Thanks.