### PR TITLE
Generate config-only services configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Add the following configuration and adapt it to your service in `tenantConfig.js
 }
 ```
 
+*Note*: `service_name` is expected to be camel case (i.e. `adminGui`), and the service name in the generated config will lowercase and hyphenated (i.e. `admin-gui`).
+
 Usage
 -----
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ If you want to define custom resource types for a custom service, you can add a 
 
 and then add it to the `custom_resource_types` setting.
 
+### Additional services
+
+For any additional service (without specific resources), ConfigGenerator generates the configuration in `OUTPUT_CONFIG_PATH` directory.
+
+Add the following configuration and adapt it to your service in `tenantConfig.json`:
+
+```json
+{
+    "name": "<service_name>",
+    "schema_url": "<service_schema_url>",
+    "config": {...}
+}
+```
 
 Usage
 -----


### PR DESCRIPTION
Hi,

As I mentioned in #64 here is a PR to automatically generate config-only services configurations by iterating through all the services in `tenantConfig.json`.

If some future basic services are added to qwc-services (without specific config), we don't need anymore to add some code in config-generator to generate the right config in `OUTPUT_CONFIG_PATH` dir.

Please tell me if there is some enhancement to do here.

Thanks