### PR TITLE
Handle subdir in scan dir by creating group in themes configuration

### DIFF
--- a/schemas/qwc-config-generator.json
+++ b/schemas/qwc-config-generator.json
@@ -83,6 +83,10 @@
           "description": "Path for QGIS projects, which should be automatically detected. Must be a subdir qgis_projects_base_dir. Example: /data/scan",
           "type": "string"
         },
+        "group_scanned_projects_by_dir": {
+          "description": "Option to group scanned projects by directory in themes configuration. Default: false",
+          "type": "boolean"
+        },
         "permissions_default_allow": {
           "description": "Set whether resources are permitted or restricted by default. Example: true",
           "type": "boolean"


### PR DESCRIPTION
Hi,

In this PR, I have added a new parameter `group_scanned_projects_by_dir` to allow user to create groups in themes configuration for scanned projects. Each subdir in `qgis_projects_scan_base_dir` will create a `group` in themes configuration.

Ex: `group_scanned_projects_by_dir=false` (nothing changes)

![image](https://github.com/qwc-services/qwc-config-generator/assets/8960009/03b86d35-743d-4b9c-adef-526c31d92fab)

Ex: `group_scanned_projects_by_dir=true` (groups are created)

![image](https://github.com/qwc-services/qwc-config-generator/assets/8960009/3563cee0-c238-48ba-8eb0-44c869a291ce)

I have also thought about saving new themes configuration in file (`themesConfig.json` or `tenantConfig.json`) each time new scanned project appears. 
Pro: It allows administrator to see scanned projects in themes plugin of qwc-admin-gui service.
Cons part: we need to give write access to `config-in` folder for the qwc-config-service in [qwc-docker](https://github.com/qwc-services/qwc-docker/blob/master/docker-compose-example.yml#L59).

Please tell me if it is something that could be interesting to add.  I will create a new PR after this one.

Thanks for the review