### PR TITLE
Save scanned projects and groups in themes configuration

### DIFF
--- a/schemas/qwc-config-generator.json
+++ b/schemas/qwc-config-generator.json
@@ -87,6 +87,10 @@
           "description": "Option to group scanned projects by directory in themes configuration. Default: false",
           "type": "boolean"
         },
+        "save_scanned_projects_in_config": {
+          "description": "Option to save scanned projects and groups in themes configuration. Requires write access to INPUT_CONFIG_PATH for config generator service. Default: false",
+          "type": "boolean"
+        },
         "permissions_default_allow": {
           "description": "Set whether resources are permitted or restricted by default. Example: true",
           "type": "boolean"

--- a/src/config_generator/config_generator.py
+++ b/src/config_generator/config_generator.py
@@ -657,11 +657,8 @@ class ConfigGenerator():
         # collect existing item urls
         items = themes.get(
             "items", [])
-        wms_urls = []
         has_default = False
         for item in items:
-            if item.get("url"):
-                wms_urls.append(item["url"])
             if item.get("default", False):
                 has_default = True
 
@@ -709,27 +706,28 @@ class ConfigGenerator():
                 theme_item["mapCrs"] = themes_config.get(
                     "defaultMapCrs")
 
-                if theme_item["url"] not in wms_urls:
-                    if not has_default:
-                        theme_item["default"] = True
-                        has_default = True
-                    # Add theme to items or group
-                    if group_scanned_projects_by_dir and (item.parent != base_path):
-                        if list(filter(lambda group: group["title"] == item.parent.name, groups)):
-                            item_group = list(filter(lambda group: group["title"] == item.parent.name, groups))[0]
-                        else:
-                            for group in groups:
-                                if list(filter(lambda g: g["title"] == item.parent.name, group["groups"])):
-                                    item_group = list(filter(lambda g: g["title"] == item.parent.name, group["groups"]))[0]
-                        if not list(filter(lambda item: item["url"] == wmspath, item_group["items"])):
-                            self.logger.info(f"Adding project {item.stem} to group {item.parent.name}")
-                            item_group["items"].append(theme_item)
-                        else: self.logger.info(f"Project {item.stem} already exists in group {item.parent.name}")
+                if not has_default:
+                    theme_item["default"] = True
+                    has_default = True
+                # Add theme to items or group
+                if group_scanned_projects_by_dir and (item.parent != base_path):
+                    if list(filter(lambda group: group["title"] == item.parent.name, groups)):
+                        item_group = list(filter(lambda group: group["title"] == item.parent.name, groups))[0]
                     else:
+                        for group in groups:
+                            if list(filter(lambda g: g["title"] == item.parent.name, group["groups"])):
+                                item_group = list(filter(lambda g: g["title"] == item.parent.name, group["groups"]))[0]
+                    if not list(filter(lambda item: item["url"] == wmspath, item_group["items"])):
+                        self.logger.info(f"Adding project {item.stem} to group {item.parent.name}")
+                        item_group["items"].append(theme_item)
+                    else: self.logger.info(f"Project {item.stem} already exists in group {item.parent.name}")
+                else:
+                    # Search for theme if it already exists in items
+                    if not list(filter(lambda item: item["url"] == wmspath, items)):
                         self.logger.info(f"Adding project {item.stem}")
                         items.append(theme_item)
-                else:
-                    self.logger.info(f"Skipping project {item.name}")
+                    else:
+                        self.logger.info(f"Skipping project {item.name}")
         themes["groups"] = groups
         themes["items"] = items
 


### PR DESCRIPTION
Hi,

Following #66 , this PR allows user to save scanned projects and groups to `themesConfig.json` file (or `tenantConfig.json`). It requires write access to `INTPUT_CONFIG_PATH`, i.e. you have to change the following row in qwc-docker `docker-compose.yaml` for qwc-config-service:

```yaml
- ./volumes/config-in:/srv/qwc_service/config-in:rw # change 'ro' to 'rw'
```

This option permits the user to see new scanned projects in Themes tab in admin GUI.

Ex: `save_scanned_projects_in_config = false`

![image](https://github.com/qwc-services/qwc-config-generator/assets/8960009/3256fcf1-725d-48d5-b613-d3a3a2390815)

You can only see the themes in `themesConfig.json` and not the scanned projects.

Ex: `save_scanned_projects_in_config = true`

![image](https://github.com/qwc-services/qwc-config-generator/assets/8960009/af6b9f58-41d0-489d-be71-c60d2375675c)

Scanned projects and groups are saved to `themesConfig.json` so you can see them in Themes tab.

Thanks for the review!