### PR TITLE
Allow to generate configuration despite some errors

### DIFF
--- a/schemas/qwc-config-generator.json
+++ b/schemas/qwc-config-generator.json
@@ -133,6 +133,10 @@
         },
         "use_default_map_thumbnail": {
           "description": "Whether to use the default mapthumb (mapthumbs/default.jpg) instead of generating the thumbnail via GetMap if no custom thumbnail is provided. Default: false"
+        },
+        "ignore_errors": {
+          "description": "Ignore errors during generation to allow creating configuration files despite some errors. Default: false",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/config_generator/capabilities_reader.py
+++ b/src/config_generator/capabilities_reader.py
@@ -66,7 +66,7 @@ class CapabilitiesReader():
             )
 
             if response.status_code != requests.codes.ok:
-                self.logger.critical(
+                self.logger.error(
                     "Could not get WMS GetProjectSettings from %s:\n%s" %
                     (full_url, response.content)
                 )
@@ -223,7 +223,7 @@ class CapabilitiesReader():
 
             return capabilities
         except Exception as e:
-            self.logger.critical(
+            self.logger.error(
                 "Could not parse WMS GetProjectSettings from %s:\n%s" %
                 (full_url, e)
             )
@@ -547,7 +547,7 @@ class CapabilitiesReader():
             )
 
             if response.status_code != requests.codes.ok:
-                self.logger.critical(
+                self.logger.error(
                     "Could not get WFS GetCapabilities from %s:\n%s" %
                     (full_url, response.content)
                 )

--- a/src/config_generator/config_generator.py
+++ b/src/config_generator/config_generator.py
@@ -146,11 +146,11 @@ class ConfigGenerator():
                     config["themesConfig"] = json.load(f)
             except:
                 msg = "Failed to read themes configuration %s" % themes_config
-                self.logger.error(msg)
+                self.logger.critical(msg)
                 raise Exception(msg)
         elif not isinstance(themes_config, dict):
             msg = "Missing or invalid themes configuration in tenantConfig.json"
-            self.logger.error(msg)
+            self.logger.critical(msg)
             raise Exception(msg)
 
         if config.get('template', None):
@@ -172,11 +172,11 @@ class ConfigGenerator():
                                 config_template["themesConfig"] = json.load(f)
                         except:
                             msg = "Failed to read themes configuration %s" % themes_config_template_path
-                            self.logger.error(msg)
+                            self.logger.critical(msg)
                             raise Exception(msg)
                     elif not isinstance(themes_config_template, dict):
                         msg = "No themes configuration in templated tenantConfig.json"
-                        self.logger.debug(msg)
+                        self.logger.critical(msg)
                         raise Exception(msg)
 
                     config_services = dict(map(lambda entry: (entry["name"], entry), config.get("services", [])))
@@ -270,8 +270,7 @@ class ConfigGenerator():
                 "Could not load JSON schema versions from %s:\n%s" %
                 (schema_versions_path, e)
             )
-            self.logger.error(msg)
-            raise Exception(msg)
+            self.logger.warn(msg)
 
         # lookup for JSON schema URLs by service name
         self.schema_urls = {}
@@ -352,7 +351,7 @@ class ConfigGenerator():
                 )
                 os.mkdir(self.tenant_path)
         except Exception as e:
-            self.logger.error("Could not create tenant dir:\n%s" % e)
+            self.logger.critical("Could not create tenant dir:\n%s" % e)
 
     def service_config(self, service):
         """Return any additional service config for service.
@@ -505,7 +504,7 @@ class ConfigGenerator():
                     config, sort_keys=False, ensure_ascii=False, indent=2
                 ).encode('utf8'))
         except Exception as e:
-            self.logger.error(
+            self.logger.critical(
                 "Could not write '%s' config file:\n%s" % (filename, e)
             )
 
@@ -518,7 +517,7 @@ class ConfigGenerator():
                 )
                 rmtree(self.temp_config_path)
         except Exception as e:
-            self.logger.error("Could not remove temp config dir:\n%s" % e)
+            self.logger.warn("Could not remove temp config dir:\n%s" % e)
 
     def validate_schema(self, config, schema_url):
         """Validate config against its JSON schema.
@@ -549,14 +548,14 @@ class ConfigGenerator():
             try:
                 response = requests.get(schema_url)
             except Exception as e:
-                self.logger.error(
+                self.logger.warn(
                     "Could not download JSON schema from %s:\n%s" %
                     (schema_url, str(e))
                 )
                 return False
 
             if response.status_code != requests.codes.ok:
-                self.logger.error(
+                self.logger.warn(
                     "Could not download JSON schema from %s:\n%s" %
                     (schema_url, response.text)
                 )
@@ -566,7 +565,7 @@ class ConfigGenerator():
             try:
                 schema = json.loads(response.text)
             except Exception as e:
-                self.logger.error("Could not parse JSON schema:\n%s" % e)
+                self.logger.warn("Could not parse JSON schema:\n%s" % e)
                 return False
 
         # validate against schema
@@ -672,7 +671,7 @@ class ConfigGenerator():
             self.logger.info(
                 "<b>Searching for projects files in %s</b>" % qgis_projects_scan_base_dir)
         else:
-            self.logger.error(
+            self.logger.warn(
                 "The qgis_projects_scan_base_dir sub directory" +
                 " does not exist: " + qgis_projects_scan_base_dir)
             return

--- a/src/config_generator/map_viewer_config.py
+++ b/src/config_generator/map_viewer_config.py
@@ -609,11 +609,11 @@ class MapViewerConfig(ServiceConfig):
             )
 
             if response.status_code != requests.codes.ok:
-                self.logger.critical(
+                self.logger.error(
                     "ERROR generating thumbnail for WMS %s:\n%s" %
                     (service_name, response.content)
                 )
-                return
+                return 'img/mapthumbs/default.jpg'
 
             document = response.content
 

--- a/src/config_generator/qgs_reader.py
+++ b/src/config_generator/qgs_reader.py
@@ -64,7 +64,7 @@ class QGSReader:
                 row = result.mappings().fetchone()
                 conn.close()
                 if not row:
-                    self.logger.critical("Could not find QGS project '%s'" % qgs_filename)
+                    self.logger.error("Could not find QGS project '%s'" % qgs_filename)
                     return False
 
                 qgz = zipfile.ZipFile(io.BytesIO(row['content']))
@@ -79,7 +79,7 @@ class QGSReader:
                 qgs_filename = self.map_prefix + self.qgs_ext
                 self.qgs_path = os.path.join(self.qgs_resources_path, qgs_filename)
                 if not os.path.exists(self.qgs_path):
-                    self.logger.critical("Could not find QGS project '%s'" % qgs_filename)
+                    self.logger.error("Could not find QGS project '%s'" % qgs_filename)
                     return False
 
                 if self.qgs_ext == ".qgz":
@@ -96,7 +96,7 @@ class QGSReader:
                     tree = ElementTree.parse(self.qgs_path)
 
             if tree is None or tree.getroot().tag != 'qgis':
-                self.logger.critical("'%s' is not a QGS file" % qgs_filename)
+                self.logger.error("'%s' is not a QGS file" % qgs_filename)
                 return False
             self.root = tree.getroot()
             self.logger.info("Read '%s'" % qgs_filename)

--- a/src/server.py
+++ b/src/server.py
@@ -61,6 +61,8 @@ def generate_configs():
             level = entry["level"].upper()
             if level == "CRITICAL":
                 log_output += '<b style="color: red">CRITICAL: %s</b>\n' % str(entry["msg"])
+            elif level == "ERROR":
+                log_output += '<span style="color: red">ERROR: %s</span>\n' % str(entry["msg"])
             elif level == "WARNING":
                 log_output += '<span style="color: orange">WARNING: %s</span>\n' % str(entry["msg"])
             else:


### PR DESCRIPTION
Hi,

This PR introduces a new option to allow ignoring errors.

Sometimes, when QGIS Server can not read capabilities from a project because a layer is not valid (or whatever), administrator may want to have the configuration generated despite this error and resolve it later.

Maybe there is a better naming to set here...

Thanks for the review