### PR TITLE
Clear internal capabilities cache for every request

### DIFF
--- a/src/config_generator/external_layer_utils.py
+++ b/src/config_generator/external_layer_utils.py
@@ -6,6 +6,9 @@ from qwc_services_core.cache import ExpiringDict
 
 capabilites_cache = ExpiringDict()
 
+def clear_capabilities_cache():
+    global capabilites_cache
+    capabilites_cache.cache = {}
 
 def getChildElement(parent, path):
     for part in path.split("/"):

--- a/src/config_generator/map_viewer_config.py
+++ b/src/config_generator/map_viewer_config.py
@@ -8,7 +8,7 @@ import requests
 import traceback
 import urllib.parse
 
-from .external_layer_utils import resolve_external_layer
+from .external_layer_utils import resolve_external_layer, clear_capabilities_cache
 from .permissions_query import PermissionsQuery
 from .service_config import ServiceConfig
 
@@ -88,6 +88,8 @@ class MapViewerConfig(ServiceConfig):
         :param str cache_dir: Project metadata cache directory
         """
         super().__init__('mapViewer', schema_url, service_config, logger)
+
+        clear_capabilities_cache()
 
         self.tenant_path = tenant_path
         self.themes_reader = themes_reader


### PR DESCRIPTION
When requesting to regenerate configurations, the service may have outdated information on the capabilities of the external layers. This pull requests clears the external layers `capabilities_cache` every time a new `MapViewerConfig` instance is created.