### PR TITLE
ThemesConfig: automatically enable map tips if there are any and defaultMapTips is not false (fixup #115)

### DIFF
--- a/src/config_generator/map_viewer_config.py
+++ b/src/config_generator/map_viewer_config.py
@@ -608,8 +608,8 @@ class MapViewerConfig(ServiceConfig):
             # set default theme
             self.default_theme = item['id']
 
-        if item.get("mapTips", None) is None and themes_config.get("defaultMapTips", False):
-            # Enable mapTips if any layer defines some
+        if item.get("mapTips", None) is None and themes_config.get("defaultMapTips", True):
+            # Enable mapTips if any layer defines some and if not explicitely disabled in themesConfig
             item['mapTips'] = any(layer.get('mapTips') for layer in layers)
 
         # Collect crs of background layers


### PR DESCRIPTION
Current implementation automatically enables `mapTips` only if the theme item config does not specify the configuration entry `mapTips` and if the themes config `defaultMapTips` is `true`. In that case, maps tip are enabled anyway in the QWC app, and this test is useless.

I fixed the implementation so that it automatically enables `mapTips` if the theme item config does not specify the configuration entry `mapTips` and if the themes config `defaultMapTips` is *not* `false`. That way, integrators can:
- Leave `defaultMapTips` to undefined, let the config-generator autodetect if `mapTips` should be enabled or not, and potentially override that via the theme item config
- Set `defaultMapTips` to true, let the config-generator autodetect if `mapTips` should actually be disabled because there aren't any, and potentially override that via the theme item config
- Set `defaultMapTips` to false so skip the config-generator detection, and handle themes that should have it enabled via the theme item config
