### PR TITLE
Fix quoting issues if a column name has a quote

### DIFF
--- a/src/config_generator/dnd_form_generator.py
+++ b/src/config_generator/dnd_form_generator.py
@@ -2,7 +2,7 @@ import re
 from sqlalchemy.sql import text as sql_text
 from xml.etree import ElementTree
 
-from .qgs_reader_utils import element_attr, element_text, find_maplayer
+from .qgs_reader_utils import element_attr, element_find_by_attribute, element_text, find_maplayer
 
 class DnDFormGenerator:
     def __init__(self, logger, assets_dir, db_engine, project, shortnames, maplayer, metadata, generate_nested_nrel_forms):
@@ -60,7 +60,8 @@ class DnDFormGenerator:
         widget.append(property)
 
     def __create_editor_widget(self, maplayer, field, prefix=""):
-        editWidget = maplayer.find("fieldConfiguration/field[@name='%s']/editWidget" % field)
+        fieldConfiguration = element_find_by_attribute(maplayer, 'fieldConfiguration/field', 'name', field)
+        editWidget = fieldConfiguration.find('editWidget') if fieldConfiguration is not None else None
         if (
             editWidget is None
             or editWidget.get("type") == "Hidden"
@@ -69,9 +70,9 @@ class DnDFormGenerator:
         if not editWidget.get("type"):
             self.logger.warning("Warning: field '%s' has empty widget type" % field)
             return None
-        editableField = maplayer.find("editable/field[@name='%s']" % field)
+        editableField = element_find_by_attribute(maplayer, 'editable/field', 'name', field)
         editable = editableField is None or editableField.get("editable") == "1"
-        constraintField = maplayer.find("constraints/constraint[@field='%s']" % field)
+        constraintField = element_find_by_attribute(maplayer, 'constraints/constraint', 'field', field)
         required = constraintField is not None and constraintField.get("notnull_strength") == "1"
         if editWidget.get("type") == "CheckBox":
             # Don't translate NOT NULL constraint into required for checkboxes
@@ -83,7 +84,7 @@ class DnDFormGenerator:
         self.__add_widget_property(widget, "required", None, None, "true" if required else "false", "property", "bool")
 
         # Compatibility with deprecated <filename>__upload convention
-        uploadField = maplayer.find("expressionfields/field[@name='%s__upload']" % field)
+        uploadField = element_find_by_attribute(maplayer, 'expressionfields/field', 'name', '%s__upload' % field)
         if uploadField is not None:
             widget.set("class", "QLineEdit")
             widget.set("name", "%s__upload" % (prefix + field))
@@ -413,7 +414,7 @@ class DnDFormGenerator:
             elif child.tag == "attributeEditorRelation":
                 tabWidget = None
 
-                relation = self.project.find(".//relations/relation[@id='%s']" % child.get("relation"))
+                relation = element_find_by_attribute(self.project, './/relations/relation', 'id', child.get("relation"))
                 relationWidget = self.__create_relation_widget(relation, child.get("showLabel") == "1", child.get("label"))
                 if relationWidget is None:
                     continue

--- a/src/config_generator/dnd_form_generator.py
+++ b/src/config_generator/dnd_form_generator.py
@@ -144,15 +144,20 @@ class DnDFormGenerator:
             return widget
         elif editWidget.get("type") == "Enumeration":
             values = {}
-            sql =  sql_text(("""
-            SELECT udt_schema::text ||'.'|| udt_name::text as defined_type
-            FROM information_schema.columns
-            WHERE table_schema = '{schema}' AND column_name = '{column}' and table_name = '{table}'
-            GROUP BY defined_type
-            LIMIT 1;
-        """).format(schema = self.metadata['schema'], table = self.metadata['table_name'], column = field))
+            
             with self.db_engine.db_engine(self.metadata['database']).connect() as conn:
-                result = conn.execute(sql)
+                sql =  sql_text("""
+                    SELECT udt_schema::text ||'.'|| udt_name::text as defined_type
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND column_name = :column and table_name = :table
+                    GROUP BY defined_type
+                    LIMIT 1;
+                """)
+                result = conn.execute(sql, {
+                    "schema": self.metadata['schema'],
+                    "column": field,
+                    "table": self.metadata['table_name']
+                })
                 for row in result.mappings():
                     defined_type = row['defined_type']
                 try : 

--- a/src/config_generator/qgs_reader.py
+++ b/src/config_generator/qgs_reader.py
@@ -195,9 +195,11 @@ class QGSReader:
                 with qgis_projects_db.connect() as conn:
                     sql = sql_text("""
                         SELECT content FROM "{schema}"."{table}"
-                        WHERE name = '{project}';
-                    """.format(schema=parts[1], table="qgis_projects", project=parts[2]))
-                    result = conn.execute(sql)
+                        WHERE name = :project;
+                    """.format(schema=parts[1], table="qgis_projects"))
+                    result = conn.execute(sql, {
+                        "project": parts[2],
+                    })
                     row = result.mappings().fetchone()
                     if not row:
                         self.logger.error("Could not find QGS project '%s'" % qgs_filename)
@@ -830,23 +832,24 @@ class QGSReader:
         """ Get column metadata from database. """
 
         # build query SQL for tables and views
-        sql = sql_text("""
-            SELECT data_type, udt_name, character_maximum_length,
-                numeric_precision, numeric_scale
-            FROM information_schema.columns
-            WHERE table_schema = '{schema}' AND table_name = '{table}'
-                AND column_name = '{column}'
-            ORDER BY ordinal_position;
-        """.format(
-            schema=datasource["schema"],
-            table=datasource["table_name"],
-            column=column
-        ))
+        
         db = self.db_engine.db_engine(datasource["database"])
         try:
             with db.connect() as conn:
                 # execute query
-                results = conn.execute(sql)
+                sql = sql_text("""
+                    SELECT data_type, udt_name, character_maximum_length,
+                        numeric_precision, numeric_scale
+                    FROM information_schema.columns
+                    WHERE table_schema = :schema AND table_name = :table
+                        AND column_name = :column
+                    ORDER BY ordinal_position;
+                """)
+                results = conn.execute(sql, {
+                    "schema": datasource["schema"],
+                    "table": datasource["table_name"],
+                    "column": column
+                })
 
                 if results.rowcount == 0:
                     # fallback to query SQL for materialized views
@@ -904,16 +907,17 @@ class QGSReader:
                         WHERE
                             /* tables, views, materialized views */
                             c.relkind in ('r', 'v', 'm')
-                            AND ns.nspname = '{schema}'
-                            AND c.relname = '{table}'
-                            AND a.attname = '{column}'
+                            AND ns.nspname = :schema
+                            AND c.relname = :table
+                            AND a.attname = :column
                         ORDER BY nspname, relname, attnum
-                    """.format(
-                        schema=datasource["schema"],
-                        table=datasource["table_name"],
-                        column=column
-                    ))
-                    results = conn.execute(sql_mv)
+                    """)
+                    results = conn.execute(sql_mv, {
+                        "schema": datasource["schema"],
+                        "table": datasource["table_name"],
+                        "column": column
+                    })
+
 
 
                 row = results.mappings().fetchone()

--- a/src/config_generator/qgs_reader.py
+++ b/src/config_generator/qgs_reader.py
@@ -16,7 +16,7 @@ from xml.etree import ElementTree
 
 from qwc_services_core.database import DatabaseEngine
 from .dnd_form_generator import DnDFormGenerator
-from .qgs_reader_utils import element_attr, element_text, find_maplayer
+from .qgs_reader_utils import element_attr, element_find_by_attribute, element_text, find_maplayer
 
 
 class QGSReader:
@@ -324,7 +324,7 @@ class QGSReader:
         parent_map = {c: p for p in tree.iter() for c in p}
 
         def layer_path(layer_id):
-            layer_tree_entry = tree.find(".//layer-tree-layer[@id='%s']" % layer_id)
+            layer_tree_entry = element_find_by_attribute(tree, './/layer-tree-layer', 'id', layer_id)
             child = layer_tree_entry
             if child is None:
                 return None, None
@@ -430,7 +430,8 @@ class QGSReader:
                         'alias': alias.get('name') or fieldname
                     }
 
-                configurationFlags = maplayer.find(f"fieldConfiguration/field[@name='{fieldname}']").get('configurationFlags', 'NoFlag').split('|')
+                fieldConfiguration = element_find_by_attribute(maplayer, 'fieldConfiguration/field', 'name', fieldname)
+                configurationFlags = fieldConfiguration.get('configurationFlags', 'NoFlag').split('|') if fieldConfiguration is not None else []
                 layer_metadata['fields'][fieldname].update({
                     'searchable': 'NotSearchable' not in configurationFlags,
                 })
@@ -524,15 +525,22 @@ class QGSReader:
 
             # Default value
             field['defaultValue'] = element_attr(
-                maplayer.find("defaults/default[@field='%s']" % fieldname), 'expression')
+                element_find_by_attribute(maplayer, 'defaults/default', 'field', fieldname),
+                'expression'
+            )
 
             # Virtual field expression
             field['expression'] = element_attr(
-                maplayer.find("expressionfields/field[@name='%s']" % fieldname), 'expression')
+                element_find_by_attribute(maplayer, 'expressionfields/field', 'name', fieldname),
+                'expression'
+            )
 
             # Filter expression
+            fieldConfiguration = element_find_by_attribute(maplayer, 'fieldConfiguration/field', 'name', fieldname)
             field['filterExpression'] = element_attr(
-                maplayer.find("fieldConfiguration/field[@name='%s']/editWidget[@type='ValueRelation']/config/Option/Option[@name='FilterExpression']" % fieldname), 'value')
+                fieldConfiguration.find("editWidget[@type='ValueRelation']/config/Option/Option[@name='FilterExpression']"),
+                'value'
+            ) if fieldConfiguration is not None else None
 
             # Widget constraints
             field['constraints'] = self.__field_constraints(root, maplayer, fieldname, map_prefix, shortnames, layer_metadata["keyvaltables"], layer_metadata["reltables"])
@@ -547,7 +555,9 @@ class QGSReader:
                 )
             elif field['expression']:
                 field['data_type'] = element_attr(
-                    maplayer.find("expressionfields/field[@name='%s']" % fieldname), 'typeName')
+                    element_find_by_attribute(maplayer, 'expressionfields/field', 'name', fieldname),
+                    'typeName'
+                )
             else:
                 self.__column_metadata(
                     field, layer_metadata, fieldname
@@ -656,28 +666,35 @@ class QGSReader:
         constraints = {}
 
         # ReadOnly
-        field_editable = element_attr(maplayer.find("editable/field[@name='%s']" % field), 'editable')
+        field_editable = element_attr(
+            element_find_by_attribute(maplayer, 'editable/field', 'name', field),
+            'editable'
+        )
         constraints['readOnly'] = field_editable == '0'
 
         # Required
         if not constraints['readOnly']:
             # ConstraintNotNull = 1
             constraints['required'] = int(
-                maplayer.find("constraints/constraint[@field='%s']" % field)
+                element_find_by_attribute(maplayer, 'constraints/constraint', 'field', field)
                 .get('constraints')
             ) & 1 > 0
 
         # Constraint expression
-        constraints['expression'] = element_attr(maplayer.find(
-            "constraintExpressions/constraint[@field='%s']" % field), 'exp')
+        constraints['expression'] = element_attr(
+            element_find_by_attribute(maplayer, 'constraintExpressions/constraint', 'field', field),
+            'exp'
+        )
 
         # Constraint expression description
-        constraints['placeholder'] = element_attr(maplayer.find(
-            "constraintExpressions/constraint[@field='%s']" % field
-        ), 'desc')
+        constraints['placeholder'] = element_attr(
+            element_find_by_attribute(maplayer, 'constraintExpressions/constraint', 'field', field),
+            'desc'
+        )
 
         # Edit widget config
-        edit_widget = maplayer.find("fieldConfiguration/field[@name='%s']/editWidget" % field)
+        field_configuration = element_find_by_attribute(maplayer, 'fieldConfiguration/field', 'name', field)
+        edit_widget = field_configuration.find("editWidget") if field_configuration is not None else None
 
         if edit_widget is None:
             pass
@@ -736,7 +753,7 @@ class QGSReader:
                 keyvaltable_metadata = self.__datasource_metadata(kvlayer.find('datasource').text)
                 keyvaltable_metadata['fields'] = []
                 for kvlayer_field in kvlayer.findall('fieldConfiguration/field'):
-                    if kvlayer.find("expressionfields/field[@name='%s']" % kvlayer_field.get('name')) is not None:
+                    if element_find_by_attribute(kvlayer, 'expressionfields/field', 'name', kvlayer_field.get('name')) is not None:
                         continue
                     kvlayer_field_metadata = {"name": kvlayer_field.get('name')}
                     self.__column_metadata(kvlayer_field_metadata, keyvaltable_metadata, kvlayer_field_metadata['name'], True)
@@ -773,7 +790,7 @@ class QGSReader:
                 keyvaltable_metadata = self.__datasource_metadata(kvlayer.find('datasource').text)
                 keyvaltable_metadata['fields'] = []
                 for kvlayer_field in kvlayer.findall('fieldConfiguration/field'):
-                    if kvlayer.find("expressionfields/field[@name='%s']" % kvlayer_field.get('name')) is not None:
+                    if element_find_by_attribute(kvlayer, 'expressionfields/field', 'name', kvlayer_field.get('name')) is not None:
                         continue
                     kvlayer_field_metadata = {"name": kvlayer_field.get('name')}
                     self.__column_metadata(kvlayer_field_metadata, keyvaltable_metadata, kvlayer_field_metadata['name'], True)

--- a/src/config_generator/qgs_reader_utils.py
+++ b/src/config_generator/qgs_reader_utils.py
@@ -1,3 +1,4 @@
+from xml.etree import ElementTree
 
 def element_attr(element, attr, default=None):
     """ Safely queries the attribute of an element which may be none. """
@@ -6,6 +7,23 @@ def element_attr(element, attr, default=None):
 def element_text(element, default=None):
     """ Safely queries the value of an element which may be none. """
     return element.text if element is not None and element.text is not None else default
+
+def element_find_by_attribute(element: ElementTree.Element, path: str, attrname: str, attrvalue: str) -> ElementTree.Element | None:
+    """Finds the first matching subelement by path and attribute
+
+    Args:
+        element (ElementTree.Element): Element
+        path (str): XPath
+        attrname (str): Name of the attribute to search for
+        attrvalue (str): Value of the attribute to search for
+
+    Returns:
+        ElementTree.Element | None: Element, or None if not found
+    """
+    return next(
+        (e for e in element.findall(path) if e.get(attrname) == attrvalue),
+        None
+    )
 
 def find_maplayer(project, layerid, layername):
     """ Search for maplayer element in project by layerid, or as a fallback by layername. """


### PR DESCRIPTION
Fixes #127 

Even if I strongly discourage using quotes in a column name (favoring aliases instead), now it's possible to do so.

It fixes two issues:
- One regarding using quoted attribute values in XPath - not supported by Python ElementTree
- One regarding using quoted parameters in SQL